### PR TITLE
Modify initial C# classes so they can be mocked

### DIFF
--- a/csharp/FantasyBattle/Inventory.cs
+++ b/csharp/FantasyBattle/Inventory.cs
@@ -2,7 +2,13 @@ namespace FantasyBattle
 {
     public class Inventory
     {
-        public Equipment Equipment { get; }
+        public virtual Equipment Equipment { get; }
+
+        public Inventory()
+        {
+
+        }
+
 
         public Inventory(Equipment equipment)
         {

--- a/csharp/FantasyBattle/SimpleEnemy.cs
+++ b/csharp/FantasyBattle/SimpleEnemy.cs
@@ -4,8 +4,13 @@ namespace FantasyBattle
 {
     public class SimpleEnemy : Target
     {
-        public Armor Armor { get; }
-        public List<Buff> Buffs { get; }
+        public virtual Armor Armor { get; }
+        public virtual List<Buff> Buffs { get; }
+
+        public SimpleEnemy()
+        {
+
+        }
 
         public SimpleEnemy(Armor armor, List<Buff> buffs)
         {

--- a/csharp/FantasyBattle/Stats.cs
+++ b/csharp/FantasyBattle/Stats.cs
@@ -4,7 +4,12 @@ namespace FantasyBattle
     {
         // TODO add dexterity that will both help with soak and damage.
         //  but half of what strength gives.
-        public int Strength { get; }
+        public virtual int Strength { get; }
+
+        public Stats()
+        {
+
+        }
 
         public Stats(int strength)
         {


### PR DESCRIPTION
In Inventory, SimpleEnemy and Stats, virtualize accessed properties and create default constructor so Moq can do its magic, otherwise it's not possible to create Moq tests without modifying the original code (as it is asked in the readme).